### PR TITLE
Add a Dockerfile to MedType

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,17 @@
 
 FROM python:3.9
 
-# We need Pipenv to set up Python packages.
-RUN pip install pipenv
-RUN pipenv install
+# Copy the source code to /opt/medtype
+WORKDIR /opt/medtype
+COPY . /opt/medtype
 
-# Set up medtype-as-service
-RUN medtype-as-service/setup.sh
+# Install gcc
+RUN apt install gcc
+
+# We need Pipenv to set up Python packages.
+RUN pip install --upgrade pip
+RUN pip install pipenv
+
+WORKDIR medtype-as-service/server
+# RUN pip install -r requirements.txt
+RUN python setup.py install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+# A Dockerfile for running the MedType server.
+
+FROM python:3.9
+
+# We need Pipenv to set up Python packages.
+RUN pip install pipenv
+RUN pipenv install
+
+# Set up medtype-as-service
+RUN medtype-as-service/setup.sh


### PR DESCRIPTION
This will be particularly useful since the Python dependencies seem to need a very particular set of dependencies and tools, so having a reproducible way of creating those would be great.